### PR TITLE
Add a debugging command to test the LPC pins.

### DIFF
--- a/appdb.c
+++ b/appdb.c
@@ -33,7 +33,7 @@ const unsigned char spitststr[] PROGMEM = "SPITEST";
 const unsigned char lpctststr[] PROGMEM = "LPCTEST";
 const unsigned char fwhtststr[] PROGMEM = "FWHTEST";
 const unsigned char frlaopstr[] PROGMEM = "FRSLAOP";
-const unsigned char lpcpinteststr[] PROGMEM = "LPCPINTEST";
+const unsigned char pinteststr[] PROGMEM = "PINTEST";
 const unsigned char calcstr[] PROGMEM = "CALC";
 const unsigned char helpstr[] PROGMEM = "?";
 
@@ -48,7 +48,7 @@ const struct command_t appdb[] PROGMEM = {
 	{(PGM_P)lpctststr, &(lpc_test_cmd)},
 	{(PGM_P)fwhtststr, &(fwh_test_cmd)},
 	{(PGM_P)frlaopstr, &(frser_last_op_cmd)},
-	{(PGM_P)lpcpinteststr, &(lpc_pin_test_cmd)},
+	{(PGM_P)pinteststr, &(pin_test_cmd)},
 	{(PGM_P)calcstr, &(calc_cmd)},
 	{(PGM_P)helpstr, &(help_cmd)},
 	{NULL,NULL}

--- a/appdb.c
+++ b/appdb.c
@@ -33,6 +33,7 @@ const unsigned char spitststr[] PROGMEM = "SPITEST";
 const unsigned char lpctststr[] PROGMEM = "LPCTEST";
 const unsigned char fwhtststr[] PROGMEM = "FWHTEST";
 const unsigned char frlaopstr[] PROGMEM = "FRSLAOP";
+const unsigned char lpcpinteststr[] PROGMEM = "LPCPINTEST";
 const unsigned char calcstr[] PROGMEM = "CALC";
 const unsigned char helpstr[] PROGMEM = "?";
 
@@ -47,6 +48,7 @@ const struct command_t appdb[] PROGMEM = {
 	{(PGM_P)lpctststr, &(lpc_test_cmd)},
 	{(PGM_P)fwhtststr, &(fwh_test_cmd)},
 	{(PGM_P)frlaopstr, &(frser_last_op_cmd)},
+	{(PGM_P)lpcpinteststr, &(lpc_pin_test_cmd)},
 	{(PGM_P)calcstr, &(calc_cmd)},
 	{(PGM_P)helpstr, &(help_cmd)},
 	{NULL,NULL}

--- a/appdb.h
+++ b/appdb.h
@@ -38,3 +38,4 @@ void lpc_test_cmd(void);
 void fwh_test_cmd(void);
 void flash_sproto_cmd(void);
 void frser_last_op_cmd(void);
+void lpc_pin_test_cmd(void);

--- a/appdb.h
+++ b/appdb.h
@@ -38,4 +38,4 @@ void lpc_test_cmd(void);
 void fwh_test_cmd(void);
 void flash_sproto_cmd(void);
 void frser_last_op_cmd(void);
-void lpc_pin_test_cmd(void);
+void pin_test_cmd(void);

--- a/commands.c
+++ b/commands.c
@@ -356,43 +356,79 @@ void flash_sproto_cmd(void)
 	flash_select_protocol(p);
 }
 
-static uint8_t lpc_pin_test_state = 0;
-void lpc_pin_test_cmd(void)
+static uint8_t pin_test_state = 0;
+void pin_test_cmd(void)
 {
-	if (flash_get_proto()&(CHIP_BUSTYPE_LPC|CHIP_BUSTYPE_FWH)) {
+	if (flash_get_proto()) {
 		flash_select_protocol(0);
 		sendstr_P(PSTR("-> REENABLE BUS WITH SPROTO <-"));
 		sendcrlf();
 		sendcrlf();
 	}
-	switch (lpc_pin_test_state) {
+	spi_uninit();
+
+	switch (pin_test_state) {
 	case 0:
-		sendstr_P(PSTR("pin 2 RST slow pullup to 3V"));
+		sendstr_P(PSTR("SPI pin 1 CS slow pullup to 3V"));
+		spi_deselect();
+
+		sendcrlf();
+		sendstr_P(PSTR("SPI pin 2 DO internal pullup"));
+		SPI_DDR &= ~_BV(SPI_DO);
+		SPI_PORT |= _BV(SPI_DO);
+
+		sendcrlf();
+		sendstr_P(PSTR("SPI pin 5 DI driven, divided to 3V"));
+		SPI_DDR |= _BV(SPI_DI);
+		SPI_PORT |= _BV(SPI_DI);
+
+		sendcrlf();
+		sendstr_P(PSTR("SPI pin 6 CLK driven, divided to 3V"));
+		SPI_DDR |= _BV(SPI_CLK);
+		SPI_PORT |= _BV(SPI_CLK);
+
+		sendcrlf();
+		sendstr_P(PSTR("LPC pin 2 RST slow pullup to 3V"));
 		RST_DDR &= ~_BV(RST);
 
 		sendcrlf();
-		sendstr_P(PSTR("pin 23 FRAME driven, divided to 3V"));
+		sendstr_P(PSTR("LPC pin 23 FRAME driven, divided to 3V"));
 		FRAME_DDR |= _BV(FRAME);
 		FRAME_PORT |= _BV(FRAME);
 
 		sendcrlf();
-		sendstr_P(PSTR("pin 24 INIT slow pullup to 3V"));
+		sendstr_P(PSTR("LPC pin 24 INIT slow pullup to 3V"));
 		INIT_DDR &= ~_BV(INIT);
 
 		sendcrlf();
-		sendstr_P(PSTR("pin 31 CLK driven, divided to 3V"));
+		sendstr_P(PSTR("LPC pin 31 CLK driven, divided to 3V"));
 		CLK_DDR |= _BV(CLK);
 		CLK_PORT |= _BV(CLK);
 
 		sendcrlf();
-		sendstr_P(PSTR("pins 13,14,15,17 NIBBLE pullup to 3V"));
+		sendstr_P(PSTR("LPC pins 13,14,15,17 NIBBLE pullup to 3V"));
 		NIBBLE_DDR = 0;
 
-		lpc_pin_test_state = 1;
+		pin_test_state = 1;
 		break;
 
 	case 1:
-		sendstr_P(PSTR("RST FRAME INIT CLK NIBBLE driven 0V"));
+		sendstr_P(PSTR("SPI CS DO DI CLK driven 0V"));
+		spi_select();
+		SPI_PORT &= ~_BV(SPI_DI);
+		SPI_DDR |= _BV(SPI_DI);
+		SPI_PORT &= ~_BV(SPI_DO);
+		SPI_DDR |= _BV(SPI_DO);
+		SPI_PORT &= ~_BV(SPI_CLK);
+		SPI_DDR |= _BV(SPI_CLK);
+
+		sendcrlf();
+		sendstr_P(PSTR("SPI pin 4 GND wired 0V"));
+		sendcrlf();
+		sendstr_P(PSTR("SPI pins 3,7,8 3V3 wired 3V"));
+
+		sendcrlf();
+		sendstr_P(PSTR("LPC RST FRAME INIT CLK NIBBLE driven 0V"));
 		RST_DDR |= _BV(RST);
 		RST_PORT &= ~_BV(RST);
 		FRAME_DDR |= _BV(FRAME);
@@ -404,12 +440,12 @@ void lpc_pin_test_cmd(void)
 		NIBBLE_DDR = 0xF;
 
 		sendcrlf();
-		sendstr_P(PSTR("pins 3-6,9-12,16,28-30 GND wired 0V"));
+		sendstr_P(PSTR("LPC pins 3-6,9-12,16,28-30 GND wired 0V"));
 		sendcrlf();
-		sendstr_P(PSTR("pins 7,8,25,32 3V3 wired 3V"));
+		sendstr_P(PSTR("LPC pins 7,8,25,32 3V3 wired 3V"));
 
 	default:
-		lpc_pin_test_state = 0;
+		pin_test_state = 0;
 	}
 }
 

--- a/flash.h
+++ b/flash.h
@@ -20,6 +20,14 @@
 
 #include "frser-flashapi.h"
 
+#define SPI_DDR                 DDRB
+#define SPI_PORT                PORTB
+
+#define SPI_CS                  PB0
+#define SPI_DI                  PB3
+#define SPI_DO                  PB4
+#define SPI_CLK                 PB5
+
 void flash_set_safe(void);
 uint8_t flash_get_proto(void);
 uint8_t flash_idle_clock(void);

--- a/nibble.c
+++ b/nibble.c
@@ -23,39 +23,29 @@
 #define swap(x) do { asm volatile("swap %0" : "=r" (x) : "0" (x)); } while(0)
 
 
-
-#define FRAME_DDR			DDRD
-#define FRAME_PORT			PORTD
-#define FRAME				PD3
-
-
-#define INIT_DDR			DDRD
-#define INIT_PORT			PORTD
-#define INIT				PD4
-
 void nibble_set_dir(uint8_t dir) {
 	if (!dir) {
-		DDRC = 0;
+		NIBBLE_DDR = 0;
 	}
 }
 
 uint8_t nibble_read(void) {
 	uint8_t rv;
-	rv = PINC & 0xF;
+	rv = NIBBLE_PIN & 0xF;
 	return rv;
 }
 
 static void nibble_write_hi(uint8_t data) {
 	swap(data);
-	DDRC = (~data) & 0xF;
+	NIBBLE_DDR = (~data) & 0xF;
 //	data &= 0xF;
-//	while ((PINC & 0xF) != data);
+//	while ((NIBBLE_PIN & 0xF) != data);
 }
 
 void nibble_write(uint8_t data) {
-	DDRC = (~data) & 0xF;
+	NIBBLE_DDR = (~data) & 0xF;
 //	data &= 0xF;
-//	while ((PINC & 0xF) != data);
+//	while ((NIBBLE_PIN & 0xF) != data);
 }
 
 #define clock_low() do { CLK_PORT &= ~_BV(CLK); } while(0)
@@ -127,8 +117,9 @@ void nibble_hw_init(void) {
 	/* All PORT init in flash_portclear(). */
 
 	/* Kick reset here so lpc/fwh.c doesnt need to know about how it is controlled. */
-	DDRD |= _BV(2); //!RST
+	RST_DDR |= _BV(RST); //!RST
+	RST_PORT &= ~_BV(RST);
 	_delay_us(1);
-	DDRD &= ~_BV(2);
+	RST_DDR &= ~_BV(RST);
 	_delay_us(1); // slow pullup
 }

--- a/nibble.h
+++ b/nibble.h
@@ -22,12 +22,25 @@
 #define OUTPUT 1
 #define INPUT 0
 
+#define RST_DDR				DDRD
+#define RST_PORT			PORTD
+#define RST				PD2
+
+#define FRAME_DDR			DDRD
+#define FRAME_PORT			PORTD
+#define FRAME				PD3
+
+#define INIT_DDR			DDRD
+#define INIT_PORT			PORTD
+#define INIT				PD4
+
 #define CLK_DDR				DDRD
 #define CLK_PORT			PORTD
 #define CLK				PD7
 
-
-
+#define NIBBLE_DDR			DDRC
+#define NIBBLE_PORT			PORTC
+#define NIBBLE_PIN			PINC
 
 bool nibble_init();
 void nibble_cleanup();


### PR DESCRIPTION
I kept making errors breadboarding this to use as an LPC flasher.

I found the debug console, and added a command to report to the user what voltages should be on what pins. It operates in two phases, raising pins in the first phase, and lowering them in alternate calls.

This seems incredibly helpful in immediately fixing wiring issues. I think it would make sense to add to install instructions.